### PR TITLE
Add Digibyte support

### DIFF
--- a/gsrest/test/general_service.py
+++ b/gsrest/test/general_service.py
@@ -39,6 +39,17 @@ stats = Stats(
             no_address_relations=123,
         ),
         CurrencyStats(
+            name="dgb",
+            no_entities=789,
+            no_addresses=456,
+            no_blocks=3,
+            timestamp=42,
+            no_txs=11,
+            no_labels=2,
+            no_tagged_addresses=20,
+            no_address_relations=123,
+        ),
+        CurrencyStats(
             name="trx",
             no_entities=0,
             no_addresses=1,
@@ -71,6 +82,7 @@ async def search(test_case):
             currencies=[
                 SearchResultByCurrency(currency="btc", addresses=[], txs=[]),
                 SearchResultByCurrency(currency="ltc", addresses=[], txs=[]),
+                SearchResultByCurrency(currency="dgb", addresses=[], txs=[]),
                 SearchResultByCurrency(currency="eth", addresses=[], txs=[]),
                 SearchResultByCurrency(currency="trx", addresses=[], txs=[]),
             ],
@@ -148,13 +160,13 @@ async def search(test_case):
     assert expected.to_dict() == result
 
     expected = base_search_results()
-    expected.currencies[2] = SearchResultByCurrency(
+    expected.currencies[3] = SearchResultByCurrency(
         currency="eth",
         txs=["af6e0000".rjust(64, "0"), "af6e0003".rjust(64, "0")],
         addresses=[],
     )
 
-    expected.currencies[3] = SearchResultByCurrency(
+    expected.currencies[4] = SearchResultByCurrency(
         currency="trx",
         txs=["af6e0000".rjust(64, "0"), "af6e0003".rjust(64, "0")],
         addresses=[],
@@ -164,7 +176,7 @@ async def search(test_case):
     expected.to_dict() == result
 
     expected = base_search_results()
-    expected.currencies[2] = SearchResultByCurrency(
+    expected.currencies[3] = SearchResultByCurrency(
         currency="eth", txs=[], addresses=["0xabcdef"]
     )
 

--- a/instance/config.yaml.template
+++ b/instance/config.yaml.template
@@ -26,6 +26,7 @@ database:
         btc:
         bch:
         ltc:
+        dgb:
         zec:
 
 # Restrict allowed origins for CORS

--- a/tests/cassandra/data/resttest_dgb_raw.configuration
+++ b/tests/cassandra/data/resttest_dgb_raw.configuration
@@ -1,0 +1,1 @@
+{"id": "dgb_raw", "block_bucket_size": 25000, "tx_bucket_size": 25000, "tx_prefix_length": 5}

--- a/tests/cassandra/data/resttest_dgb_transformed.configuration
+++ b/tests/cassandra/data/resttest_dgb_transformed.configuration
@@ -1,0 +1,1 @@
+ {"keyspace_name": "dgb_transformed", "bech_32_prefix": "dgb1", "bucket_size": 25000, "coinjoin_filtering": true, "fiat_currencies": ["EUR", "USD"], "address_prefix_length": 5}}

--- a/tests/cassandra/data/resttest_dgb_transformed.summary_statistics
+++ b/tests/cassandra/data/resttest_dgb_transformed.summary_statistics
@@ -1,0 +1,1 @@
+{"no_blocks": 3, "no_address_relations": 123, "no_addresses": 456, "no_clusters": 789, "no_transactions": 11, "timestamp": 42, "id": 0}

--- a/tests/cassandra/insert.py
+++ b/tests/cassandra/insert.py
@@ -11,7 +11,13 @@ DATA_DIR = Path(__file__).parent.resolve() / "data"
 TAG = "master"
 SCHEMA_BASE = f"https://raw.githubusercontent.com/graphsense/graphsense-lib/{TAG}/src/graphsenselib/schema/resources/"
 
-SCHEMA_MAPPING = {"btc": "utxo", "ltc": "utxo", "eth": "account", "trx": "account_trx"}
+SCHEMA_MAPPING = {
+    "btc": "utxo",
+    "ltc": "utxo",
+    "dgb": "utxo",
+    "eth": "account",
+    "trx": "account_trx",
+}
 
 SCHEMA_MAPPING_OVERRIDE = {("trx", "transformed"): "account"}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,10 @@ def gs_rest_db_setup(request):
                     "raw": "resttest_ltc_raw",
                     "transformed": "resttest_ltc_transformed",
                 },
+                "dgb": {
+                    "raw": "resttest_dgb_raw",
+                    "transformed": "resttest_dgb_transformed",
+                },
                 "eth": {
                     "raw": "resttest_eth_raw",
                     "transformed": "resttest_eth_transformed",


### PR DESCRIPTION
## Summary
- support DGB keyspaces in test data and setup
- include Digibyte in default config template
- update tests for new Digibyte currency

## Testing
- `make test` *(fails: unsuccessful tunnel to files.pythonhosted.org)*

------
https://chatgpt.com/codex/tasks/task_b_687d8a0dc508832ba814d7a342526b22